### PR TITLE
Updated escape sequence handling for Zsh

### DIFF
--- a/fishbone++.zsh-theme
+++ b/fishbone++.zsh-theme
@@ -41,13 +41,14 @@ local return_status="%(?:%{$fg[cyan]%}$prompt_string:%{$fg[red]%}$prompt_string%
 
 
 # set the git_prompt_info text
-ZSH_THEME_GIT_PROMPT_PREFIX=" %{$fg[blue](%{$reset_color%}%{$fg[yellow]%}"
-ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%{$fg[blue])%}"
+ZSH_THEME_GIT_PROMPT_PREFIX=" %{$fg[blue]%}(%{$reset_color%}%{$fg[yellow]%}"
+ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%}%{$fg[blue]%})%{$reset_color%}"
+
 ZSH_THEME_GIT_PROMPT_DIRTY="⚡"
 ZSH_THEME_GIT_PROMPT_CLEAN=""
 
 PROMPT='${newline}\
-${host_name}${hosr}%{$reset_color%}@${time_string} ${line_mode}\
+${host_name}%{$reset_color%}@${time_string} ${line_mode}\
 ${path_prefix}${path_string}${path_postfix}$(git_prompt_info)$(git_prompt_status) \
 ${return_status} %{$reset_color%}'
 


### PR DESCRIPTION
Thanks for the work and the great theme! This MR fixes broken color escape sequences which caused some prompt rendering/redrawing issues with newer Zsh versions, like overlapping autosuggestions. 

- Fixed invalid/mismatched %{…%} wrappers in Git prompt prefix/suffix
- Removed/corrected ${hosr} → ${host_name}, since it resolved to ""

I am no zsh expert so it would be great if someone else could verify these changes. I think the relevant changes to zsh appeared in versions > 5.8.1